### PR TITLE
Add ICP Protector DAO as DeAI Manifesto signee

### DIFF
--- a/src/DeAIManifesto_frontend/src/helpers/organization_signees.js
+++ b/src/DeAIManifesto_frontend/src/helpers/organization_signees.js
@@ -71,5 +71,12 @@ export const organizationSignees = [
     signDate: "2024-12-10",
     signedBy: "Jayz",
   },
+  {
+    name: "ICP Protector",
+    logo: "./ICPProtector-logo-organization-signee.png",
+    url: "https://icprotector.io/",
+    signDate: "2024-12-16",
+    signedBy: "ICProtector",
+  },
 ];
   


### PR DESCRIPTION
This pull request adds MingleBerryMedia as a signee to the DeAI Manifesto. 
- Added MingleBerryMedia's entry to organization_signees.js